### PR TITLE
fix: Incorrect return value type fixed.

### DIFF
--- a/src/parsec.hpp
+++ b/src/parsec.hpp
@@ -655,7 +655,7 @@ struct Token
         }
         else
         {
-            return;
+            return epsilon();
         }
     }
 };


### PR DESCRIPTION
test.cpp could not be executed.
We did not call all the code, so we cannot guarantee that this is the correct fix, but this fix made test.cpp run correctly.